### PR TITLE
Add initial coordinator prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # QianYuan-Engine
-乾元引擎，统筹所有异构设备（吐舌(ૢ˃ꌂ˂ૢ)开玩笑的）
+
+A prototype implementation for the QianYuan Engine project. This repository
+contains a minimal skeleton based on the documentation located in `docs/`.
+It provides:
+
+- A simple coordinator service built with FastAPI.
+- Placeholder modules for a protocol gateway and edge client.
+- Basic unit tests demonstrating task dispatch and status query.
+
+Run the coordinator locally:
+
+```bash
+pip install -r requirements.txt
+python main.py
+```

--- a/main.py
+++ b/main.py
@@ -1,0 +1,9 @@
+"""Entry point for running the coordinator."""
+
+import uvicorn
+from qianyuan_engine.coordinator import create_app
+
+
+if __name__ == "__main__":
+    app = create_app()
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/qianyuan_engine/coordinator.py
+++ b/qianyuan_engine/coordinator.py
@@ -1,0 +1,75 @@
+"""Simple intelligent coordinator prototype."""
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import Any, Dict, List
+import time
+
+from .models import Task
+
+
+class TaskDetail(BaseModel):
+    task_type: str
+    parameters: Dict[str, Any] = {}
+
+
+class DispatchRequest(BaseModel):
+    task_details: TaskDetail
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="QianYuan Coordinator")
+    coordinator = Coordinator()
+
+    @app.post("/dispatch_task")
+    def dispatch_task(req: DispatchRequest):
+        task_type = req.task_details.task_type
+        params = req.task_details.parameters
+        task = coordinator.dispatch_task(task_type, params)
+        return {
+            "status": "success",
+            "data": {"task_id": task.id, "timestamp": int(time.time())},
+            "message": "Task dispatched successfully.",
+        }
+
+    @app.get("/system_status")
+    def system_status():
+        return {
+            "status": "success",
+            "data": coordinator.status(),
+            "message": "",
+        }
+
+    @app.put("/update_config")
+    def update_config(cfg: Dict[str, int]):
+        coordinator.update_config(cfg)
+        return {"status": "success", "data": {}, "message": "Configuration updated."}
+
+    return app
+
+
+class Coordinator:
+    """In-memory task coordinator."""
+
+    def __init__(self) -> None:
+        self.tasks: List[Task] = []
+        self.config: Dict[str, int] = {
+            "max_task_timeout": 5000,
+            "retry_attempts": 3,
+        }
+
+    def dispatch_task(self, task_type: str, parameters: Dict) -> Task:
+        task = Task(task_type=task_type, parameters=parameters)
+        self.tasks.append(task)
+        return task
+
+    def status(self) -> Dict[str, int]:
+        return {
+            "connected_devices": 0,
+            "average_cpu_usage": 0.0,
+            "average_mem_usage": 0.0,
+            "pending_tasks": len(self.tasks),
+        }
+
+    def update_config(self, config: Dict[str, int]) -> None:
+        self.config.update(config)

--- a/qianyuan_engine/edge_client.py
+++ b/qianyuan_engine/edge_client.py
@@ -1,0 +1,20 @@
+"""Edge device client stub."""
+
+import requests
+from typing import Dict, Any
+
+
+class EdgeClient:
+    """Simple client to request tasks and report status."""
+
+    def __init__(self, coordinator_url: str) -> None:
+        self.coordinator_url = coordinator_url.rstrip("/")
+
+    def dispatch_task(self, task_type: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        payload = {"task_details": {"task_type": task_type, "parameters": params}}
+        resp = requests.post(f"{self.coordinator_url}/dispatch_task", json=payload, timeout=5)
+        return resp.json()
+
+    def get_status(self) -> Dict[str, Any]:
+        resp = requests.get(f"{self.coordinator_url}/system_status", timeout=5)
+        return resp.json()

--- a/qianyuan_engine/models.py
+++ b/qianyuan_engine/models.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict
+import uuid
+
+
+@dataclass
+class Task:
+    """Simple task representation."""
+
+    task_type: str
+    parameters: Dict[str, Any]
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))

--- a/qianyuan_engine/protocol_gateway.py
+++ b/qianyuan_engine/protocol_gateway.py
@@ -1,0 +1,19 @@
+"""Simple protocol gateway placeholder."""
+
+from typing import Any
+
+
+class ProtocolGateway:
+    """Placeholder for protocol conversion layer."""
+
+    def __init__(self) -> None:
+        self.handlers = {}
+
+    def register_handler(self, protocol: str, handler: Any) -> None:
+        self.handlers[protocol] = handler
+
+    def convert(self, protocol: str, data: Any) -> Any:
+        handler = self.handlers.get(protocol)
+        if handler is None:
+            raise ValueError(f"Unsupported protocol: {protocol}")
+        return handler(data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+requests
+httpx

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,25 @@
+import sys
+import os
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from qianyuan_engine.coordinator import create_app
+
+
+def test_dispatch_and_status():
+    app = create_app()
+    client = TestClient(app)
+
+    resp = client.post(
+        "/dispatch_task",
+        json={"task_details": {"task_type": "compute_square", "parameters": {"number": 2}}},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "success"
+
+    status_resp = client.get("/system_status")
+    assert status_resp.status_code == 200
+    status_data = status_resp.json()
+    assert status_data["data"]["pending_tasks"] == 1


### PR DESCRIPTION
## Summary
- add `qianyuan_engine` package with coordinator, models, protocol gateway and edge client stubs
- implement `main.py` entry point
- add unit test for coordinator
- document how to run the prototype in README
- include requirements file

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684274c01050832e89be999a8e49c9ae